### PR TITLE
Fix up the configuration

### DIFF
--- a/openstack-magnum-cluster/deploy.tf
+++ b/openstack-magnum-cluster/deploy.tf
@@ -1,3 +1,6 @@
+provider "openstack" {                                                                                                               
+  version =  "< 1.30.0"                                                                                                              
+}
 resource "openstack_compute_keypair_v2" "keypair" {
   name = var.keypair_name
   public_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
@@ -19,7 +22,7 @@ resource "openstack_containerinfra_clustertemplate_v1" "kubernetes-cluster-templ
   # master_lb_enabled must be true if master_count is > 1
   master_lb_enabled = false
   labels = {
-    kube_tag = "v${var.kubernetes_version}"
+    heat_container_agent_tag = "train-stable"
   }
 }
 

--- a/openstack-magnum-cluster/variables.tf
+++ b/openstack-magnum-cluster/variables.tf
@@ -3,15 +3,11 @@ variable "keypair_name" {
 }
 variable "image" {
   type = string
-  default = "Fedora Atomic 29 [2019-08-20]"
+  default = "Fedora Atomic 29 "
 }
 variable "flavor" {
   type = string
   default = "2C-2GB-20GB"
-}
-variable "kubernetes_version" {
-  type = string
-  default = "1.15.7"
 }
 variable "template_name" {
   type = string


### PR DESCRIPTION
Drop the label kube_tag=1.15.7
Add heat_container_agent_tag label
Use Fedora 29 image
Add provider block to downgrade version to v1.29.0
as v1.30.0 has an upstream bug.