### PR TITLE
load_balancers_ingress block is changed to align with upstream Kubernetes API.

### DIFF
--- a/kubernetes-nginx/deploy.tf
+++ b/kubernetes-nginx/deploy.tf
@@ -51,5 +51,5 @@ resource "kubernetes_service" "nginx" {
 }
 
 output "lb_ip" {
-  value = kubernetes_service.nginx.status[0].load_balancer[0].ingress[0].ip
+  value = kubernetes_service.nginx.status.0.load_balancer.0.ingress.0.ip
 }

--- a/kubernetes-nginx/deploy.tf
+++ b/kubernetes-nginx/deploy.tf
@@ -51,5 +51,5 @@ resource "kubernetes_service" "nginx" {
 }
 
 output "lb_ip" {
-  value = kubernetes_service.nginx.load_balancer_ingress[0].ip
+  value = kubernetes_service.nginx.status[0].load_balancer[0].ingress[0].ip
 }

--- a/kubernetes-nginx/versions.tf
+++ b/kubernetes-nginx/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/openstack-keypair/versions.tf
+++ b/openstack-keypair/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/openstack-magnum-cluster/deploy.tf
+++ b/openstack-magnum-cluster/deploy.tf
@@ -1,6 +1,3 @@
-provider "openstack" {                                                                                                               
-  version =  "< 1.30.0"                                                                                                              
-}
 resource "openstack_compute_keypair_v2" "keypair" {
   name = var.keypair_name
   public_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
@@ -31,6 +28,7 @@ resource "openstack_containerinfra_cluster_v1" "kubernetes-cluster" {
   cluster_template_id = openstack_containerinfra_clustertemplate_v1.kubernetes-cluster-template.id
   master_count = 1
   node_count = 1
+  floating_ip_enabled = true
   keypair = openstack_compute_keypair_v2.keypair.id
   create_timeout = 60
 }

--- a/openstack-magnum-cluster/versions.tf
+++ b/openstack-magnum-cluster/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/openstack-network-router-instance/variables.tf
+++ b/openstack-network-router-instance/variables.tf
@@ -29,7 +29,7 @@ variable external_network {
 
 variable "image" {
   type = string
-  default = "Ubuntu 18.04 Bionic Beaver"
+  default = "Ubuntu 20.04 Focal Fossa"
 }
 
 variable "flavor" {

--- a/openstack-network-router-instance/versions.tf
+++ b/openstack-network-router-instance/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Instead of load_balancers_ingress, users should use
status[].load_balancer[].ingress[] to obtain the ip or hostname attributes.