### PR TITLE
Replace RSA key references with ED25519 ones

### DIFF
--- a/openstack-keypair/deploy.tf
+++ b/openstack-keypair/deploy.tf
@@ -1,4 +1,4 @@
 resource "openstack_compute_keypair_v2" "keypair" {
   name = var.keypair_name
-  public_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
+  public_key = "${file(pathexpand("~/.ssh/id_ed25519.pub"))}"
 }

--- a/openstack-magnum-cluster/deploy.tf
+++ b/openstack-magnum-cluster/deploy.tf
@@ -1,6 +1,6 @@
 resource "openstack_compute_keypair_v2" "keypair" {
   name = var.keypair_name
-  public_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
+  public_key = "${file(pathexpand("~/.ssh/id_ed25519.pub"))}"
 }
 
 resource "openstack_containerinfra_clustertemplate_v1" "kubernetes-cluster-template" {

--- a/openstack-network-router-instance/deploy.tf
+++ b/openstack-network-router-instance/deploy.tf
@@ -1,6 +1,6 @@
 resource "openstack_compute_keypair_v2" "keypair" {
   name = var.keypair_name
-  public_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
+  public_key = "${file(pathexpand("~/.ssh/id_ed25519.pub"))}"
 }
 
 resource "openstack_networking_router_v2" "router" {


### PR DESCRIPTION
Since we are no longer using RSA keys, we need to update the
references in the configuration.
