### PR TITLE
Drop references to dx1

### DIFF
--- a/openstack-dual-region/providers.tf
+++ b/openstack-dual-region/providers.tf
@@ -1,6 +1,6 @@
 provider "openstack" {
-  region = "dx1"
-  auth_url = "https://dx1.citycloud.com:5000/v3"
+  region = "Kna1"
+  auth_url = "https://kna1.citycloud.com:5000/v3"
 }
 
 provider "openstack" {

--- a/openstack-dual-region/versions.tf
+++ b/openstack-dual-region/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"

--- a/openstack-keypair/versions.tf
+++ b/openstack-keypair/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"

--- a/openstack-network-router-instance/versions.tf
+++ b/openstack-network-router-instance/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Remove references to dx1 from `providers.tf` in the dual-region configuration, and replace them with references to Kna1.

In addition, restrict the `openstack` provider to a version that doesn't produce a useless warning.