### PR TITLE
fix: Use Jammy Jellyfish Ubuntu image

### DIFF
--- a/openstack-dual-region/variables.tf
+++ b/openstack-dual-region/variables.tf
@@ -29,7 +29,7 @@ variable external_network {
 
 variable "image" {
   type = string
-  default = "Ubuntu 20.04 Focal Fossa x86_64"
+  default = "Ubuntu 22.04 Jammy Jellyfish x86_64"
 }
 
 variable "flavor" {

--- a/openstack-network-router-instance/variables.tf
+++ b/openstack-network-router-instance/variables.tf
@@ -29,7 +29,7 @@ variable external_network {
 
 variable "image" {
   type = string
-  default = "Ubuntu 20.04 Focal Fossa x86_64"
+  default = "Ubuntu 22.04 Jammy Jellyfish x86_64"
 }
 
 variable "flavor" {


### PR DESCRIPTION
Although Ubuntu 20.04 Focal Fossa reaches its EOL in April 2025, Python 3.8 (the default Python release in Ubuntu Focal) reaches its own EOL in October 2024.

Thus, we modify all related definitions in the variable files for Terraform configuration files to use the Ubuntu 22.04 Jammy Jellyfish image.