### PR TITLE
fix: Define explicit dependencies on floating IP resources

### DIFF
--- a/openstack-dual-region/deploy.tf
+++ b/openstack-dual-region/deploy.tf
@@ -69,6 +69,7 @@ resource "openstack_compute_floatingip_associate_v2" "floatingip" {
   floating_ip = "${openstack_networking_floatingip_v2.floatingip.address}"
   instance_id = "${openstack_compute_instance_v2.instance.id}"
   fixed_ip    = "${openstack_compute_instance_v2.instance.network.0.fixed_ip_v4}"
+  depends_on  = [router_interface]
 }
 
 
@@ -153,5 +154,6 @@ resource "openstack_compute_floatingip_associate_v2" "floatingip_right" {
   floating_ip = "${openstack_networking_floatingip_v2.floatingip_right.address}"
   instance_id = "${openstack_compute_instance_v2.instance_right.id}"
   fixed_ip    = "${openstack_compute_instance_v2.instance_right.network.0.fixed_ip_v4}"
+  depends_on  = [router_interface_right]
   provider = openstack.right
 }

--- a/openstack-network-router-instance/deploy.tf
+++ b/openstack-network-router-instance/deploy.tf
@@ -67,4 +67,5 @@ resource "openstack_compute_floatingip_associate_v2" "floatingip" {
   floating_ip = "${openstack_networking_floatingip_v2.floatingip.address}"
   instance_id = "${openstack_compute_instance_v2.instance.id}"
   fixed_ip    = "${openstack_compute_instance_v2.instance.network.0.fixed_ip_v4}"
+  depends_on  = [router_interface]
 }


### PR DESCRIPTION
When associating a floating IP address with a port, the following conditions must be met:

1. The port must be in a subnet that has a router interface in an existing router.
2. The router must have its external gateway set to an external IPv4 network.

Implicit dependencies in Terraform do not enforce the first condition. Thus, it's possible that Terraform attempts to associate a
floating IP address with a port before the port's subnet has a connection to the router.

This then results in an OpenStack API error (Bad Request, HTTP 400), with an error description similar to:

```
Error: External network <uuid> is not reachable from subnet <uuid>
```

Normally this does not happen, since the port in question is usually associated with a server, and it takes longer for Nova to spin up the server than it takes Neutron to configure the subnet and router. However, if the server already exists and the router does not, as is possible if an initial `terraform apply` ran into a quota limit, the race condition triggers and we see the *Bad Request* error.

The workaround for this race condition is to add an explicit dependency from the `openstack_compute_floatingip_associate_v2` resource to the corresponding `openstack_networking_router_interface_v2` resource.