### PR TITLE
In security_groups references, use IDs not names

### DIFF
--- a/openstack-dual-region/deploy.tf
+++ b/openstack-dual-region/deploy.tf
@@ -59,7 +59,7 @@ resource "openstack_compute_instance_v2" "instance" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup.name ]
+  security_groups = [ openstack_networking_secgroup_v2.secgroup.id ]
   network {
     uuid = openstack_networking_network_v2.network.id
   }
@@ -143,7 +143,7 @@ resource "openstack_compute_instance_v2" "instance_right" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair_right.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup_right.name ]
+  security_groups = [ openstack_networking_secgroup_v2.secgroup_right.id ]
   network {
     uuid = openstack_networking_network_v2.network_right.id
   }

--- a/openstack-network-router-instance/deploy.tf
+++ b/openstack-network-router-instance/deploy.tf
@@ -57,7 +57,7 @@ resource "openstack_compute_instance_v2" "instance" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup.name ]
+  security_groups = [ openstack_networking_secgroup_v2.secgroup.id ]
   network {
     uuid = openstack_networking_network_v2.network.id
   }


### PR DESCRIPTION
When referring to security groups in instance definitions, use the resource's `id` attribute, not its `name`. Otherwise, `terraform apply` fails in case a security group of the given name already exists.
