### PR TITLE
Remove legacy flavor, add boot-from-volume flavor and block device

### DIFF
--- a/openstack-dual-region/data.tf
+++ b/openstack-dual-region/data.tf
@@ -6,3 +6,13 @@ data "openstack_networking_network_v2" "external_network_right" {
   name = var.external_network
   provider = openstack.right
 }
+
+data "openstack_images_image_v2" "ubuntu_jammy" {
+  name = var.image
+}
+
+data "openstack_images_image_v2" "ubuntu_jammy_right" {
+  name = var.image
+  provider = openstack.right
+}
+

--- a/openstack-dual-region/deploy.tf
+++ b/openstack-dual-region/deploy.tf
@@ -63,6 +63,16 @@ resource "openstack_compute_instance_v2" "instance" {
   network {
     uuid = openstack_networking_network_v2.network.id
   }
+  block_device  {
+    uuid = data.openstack_images_image_v2.ubuntu_jammy.id
+    source_type = "image"
+    destination_type = "volume"
+    boot_index = 0
+    volume_size = var.size
+    delete_on_termination = true
+  }
+}
+
 }
 
 resource "openstack_compute_floatingip_associate_v2" "floatingip" {
@@ -139,7 +149,6 @@ resource "openstack_networking_secgroup_rule_v2" "icmp_right" {
 
 resource "openstack_compute_instance_v2" "instance_right" {
   name = var.instance_name
-  image_name = var.image
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair_right.name
@@ -148,6 +157,14 @@ resource "openstack_compute_instance_v2" "instance_right" {
     uuid = openstack_networking_network_v2.network_right.id
   }
   provider = openstack.right
+  block_device  {
+    uuid = data.openstack_images_image_v2.ubuntu_jammy_right.id
+    source_type = "image"
+    destination_type = "volume"
+    boot_index = 0
+    volume_size = var.size
+    delete_on_termination = true
+  }
 }
 
 resource "openstack_compute_floatingip_associate_v2" "floatingip_right" {

--- a/openstack-dual-region/variables.tf
+++ b/openstack-dual-region/variables.tf
@@ -34,7 +34,12 @@ variable "image" {
 
 variable "flavor" {
   type = string
-  default = "2C-2GB-20GB"
+  default = "b.2c2gb"
+}
+
+variable "size" {
+  type = string
+  default = "20"
 }
 
 variable "region_left" {

--- a/openstack-network-router-instance/data.tf
+++ b/openstack-network-router-instance/data.tf
@@ -1,3 +1,7 @@
 data "openstack_networking_network_v2" "external_network" {
   name = var.external_network
 }
+
+data "openstack_images_image_v2" "ubuntu_jammy" {
+  name = var.image
+}

--- a/openstack-network-router-instance/deploy.tf
+++ b/openstack-network-router-instance/deploy.tf
@@ -53,7 +53,6 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
 
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
-  image_name = var.image
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
@@ -61,7 +60,17 @@ resource "openstack_compute_instance_v2" "instance" {
   network {
     uuid = openstack_networking_network_v2.network.id
   }
+  block_device  {
+    uuid = data.openstack_images_image_v2.ubuntu_jammy.id
+    source_type = "image"
+    destination_type = "volume"
+    boot_index = 0
+    volume_size = var.size
+    delete_on_termination = true
+  }
+
 }
+
 
 resource "openstack_compute_floatingip_associate_v2" "floatingip" {
   floating_ip = "${openstack_networking_floatingip_v2.floatingip.address}"

--- a/openstack-network-router-instance/variables.tf
+++ b/openstack-network-router-instance/variables.tf
@@ -34,6 +34,10 @@ variable "image" {
 
 variable "flavor" {
   type = string
-  default = "2C-2GB-20GB"
+  default = "b.2c2gb"
 }
 
+variable "size" {
+  type = string
+  default = "20"
+}


### PR DESCRIPTION
* Remove legacy flavors from the terraform configurations.
* Add block device block to support boot from volume for compute instances.