### PR TITLE
fix: Replace openstack_compute_floatingip_associate_v2 resources

### DIFF
--- a/openstack-dual-region/deploy.tf
+++ b/openstack-dual-region/deploy.tf
@@ -61,7 +61,6 @@ resource "openstack_networking_port_v2" "instance_port" {
 
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
-  image_name = var.image
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name

--- a/openstack-dual-region/deploy.tf
+++ b/openstack-dual-region/deploy.tf
@@ -55,6 +55,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
 
 resource "openstack_networking_port_v2" "instance_port" {
   network_id = openstack_networking_network_v2.network.id
+  security_group_ids = [ openstack_networking_secgroup_v2.secgroup.id ]
   depends_on  = [openstack_networking_subnet_v2.subnet]
 }
 
@@ -64,7 +65,6 @@ resource "openstack_compute_instance_v2" "instance" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup.id ]
   network {
     port = openstack_networking_port_v2.instance_port.id
   }
@@ -151,6 +151,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp_right" {
 
 resource "openstack_networking_port_v2" "instance_port_right" {
   network_id = openstack_networking_network_v2.network_right.id
+  security_group_ids = [ openstack_networking_secgroup_v2.secgroup_right.id ]
   depends_on  = [openstack_networking_subnet_v2.subnet_right]
   provider = openstack.right
 }
@@ -160,7 +161,6 @@ resource "openstack_compute_instance_v2" "instance_right" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair_right.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup_right.id ]
   network {
     port = openstack_networking_port_v2.instance_port_right.id
   }

--- a/openstack-network-router-instance/deploy.tf
+++ b/openstack-network-router-instance/deploy.tf
@@ -53,6 +53,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
 
 resource "openstack_networking_port_v2" "instance_port" {
   network_id = openstack_networking_network_v2.network.id
+  security_group_ids = [ openstack_networking_secgroup_v2.secgroup.id ]
   depends_on  = [openstack_networking_subnet_v2.subnet]
 }
 
@@ -61,7 +62,6 @@ resource "openstack_compute_instance_v2" "instance" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup.id ]
   network {
     port = openstack_networking_port_v2.instance_port.id
   }


### PR DESCRIPTION
The `openstack_compute_floatingip_associate_v2` resource type has been deprecated, and the `openstack_networking_floatingip_associate_v2` replaces its functionality. The latter, however, associates a floating IP with a port and not with an instance, so we have to create the port first, and attach that to the instance.

Then, we have the option of referencing the security groups either from the instance (as before), or from the port.
    
The former approach has the issue that it always results the instance resource(s) always being "changed" upon apply, like so:
    
      # openstack_compute_instance_v2.instance will be updated in-place
      ~ resource "openstack_compute_instance_v2" "instance" {
            id                  = "f04e622e-9398-4d09-8040-b334452d6a60"
            name                = "instance-cc217_dev_250279fcee1ca1288b626f96f730a23a"
          ~ security_groups     = [
              - "secgroup-cc217_dev_250279fcee1ca1288b626f96f730a23a",
              + "ea489985-d94f-4c27-b947-8c753308a0c4",
            ]
            tags                = []
            # (15 unchanged attributes hidden)
    
            # (2 unchanged blocks hidden)
        }
    
    Plan: 0 to add, 1 to change, 0 to destroy.
    
In other words, the instance's security group (which the configuration already references by ID) is somehow tracked internally by name, and is then again "replaced" by the ID reference.
    
Setting the security group on the port avoids this issue.

Finally, in the dual-region configuration, a leftover `image_name` argument reference existed that wasn't removed in     a034d3a878f3f314f124c9727e88aee0e0df7919 like it should have been. This caused an unnecessary in-place update for the instance.
    
Remove the argument.