### PR TITLE
fix: Drop version restriction for OpenStack provider

### DIFF
--- a/openstack-dual-region/deploy.tf
+++ b/openstack-dual-region/deploy.tf
@@ -61,7 +61,6 @@ resource "openstack_networking_port_v2" "instance_port" {
 
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
-  image_name = var.image
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name

--- a/openstack-dual-region/deploy.tf
+++ b/openstack-dual-region/deploy.tf
@@ -55,6 +55,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
 
 resource "openstack_networking_port_v2" "instance_port" {
   network_id = openstack_networking_network_v2.network.id
+  security_group_ids = [ openstack_networking_secgroup_v2.secgroup.id ]
   depends_on  = [openstack_networking_subnet_v2.subnet]
 }
 
@@ -64,7 +65,6 @@ resource "openstack_compute_instance_v2" "instance" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup.id ]
   network {
     port = openstack_networking_port_v2.instance_port.id
   }
@@ -151,6 +151,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp_right" {
 
 resource "openstack_networking_port_v2" "instance_port_right" {
   network_id = openstack_networking_network_v2.network_right.id
+  security_group_ids = [ openstack_networking_secgroup_v2.secgroup_right.id ]
   depends_on  = [openstack_networking_subnet_v2.subnet_right]
   provider = openstack.right
 }
@@ -160,7 +161,6 @@ resource "openstack_compute_instance_v2" "instance_right" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair_right.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup_right.id ]
   network {
     port = openstack_networking_port_v2.instance_port_right.id
   }

--- a/openstack-dual-region/versions.tf
+++ b/openstack-dual-region/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
-      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"

--- a/openstack-keypair/versions.tf
+++ b/openstack-keypair/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
-      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"

--- a/openstack-network-router-instance/deploy.tf
+++ b/openstack-network-router-instance/deploy.tf
@@ -53,6 +53,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
 
 resource "openstack_networking_port_v2" "instance_port" {
   network_id = openstack_networking_network_v2.network.id
+  security_group_ids = [ openstack_networking_secgroup_v2.secgroup.id ]
   depends_on  = [openstack_networking_subnet_v2.subnet]
 }
 
@@ -61,7 +62,6 @@ resource "openstack_compute_instance_v2" "instance" {
   flavor_name = var.flavor
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
-  security_groups = [ openstack_networking_secgroup_v2.secgroup.id ]
   network {
     port = openstack_networking_port_v2.instance_port.id
   }

--- a/openstack-network-router-instance/versions.tf
+++ b/openstack-network-router-instance/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
-      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
The restriction introduced in c725e9ec9b7006c3d0c7c9f0be6b3faaff1f4c67 is no longer necessary, so remove it.

(This is meant to be merged after #14 has landed.)
